### PR TITLE
MinoBehavior.csの修正

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -1936,6 +1936,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1082435102}
   - component: {fileID: 1082435103}
+  - component: {fileID: 1082435104}
   m_Layer: 0
   m_Name: MinoManager
   m_TagString: Untagged
@@ -1967,6 +1968,19 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dce855a322bef2d4f9dc476e668e59f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ScoreManagerObject: {fileID: 1872166540}
+--- !u!114 &1082435104
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1082435101}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00396e00ee0196a4ebd298998bc9738f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1141509122
@@ -2714,6 +2728,50 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1844807833}
   m_CullTransparentMesh: 0
+--- !u!1 &1872166540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1872166541}
+  - component: {fileID: 1872166542}
+  m_Layer: 0
+  m_Name: ScoreManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1872166541
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1872166540}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.5280335, y: 9.357407, z: -3.6408656}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1872166542
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1872166540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 703326afbaa05644b95031e214fa49c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _UIManagerObject: {fileID: 333474534}
 --- !u!1 &1939098276
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Mino/MinoBehavior.cs
+++ b/Assets/Scripts/Mino/MinoBehavior.cs
@@ -142,6 +142,7 @@ namespace Tetris
             {
                 if (!_minoManager.GetComponent<MinoController>().canHoldMino()) return;
                 _isHold = true;
+                CancelInvoke("MoveDownInvoke");
                 _minoManager.GetComponent<MinoController>().HoldMino();
             }
 

--- a/Assets/Scripts/Mino/MinoBehavior.cs
+++ b/Assets/Scripts/Mino/MinoBehavior.cs
@@ -48,6 +48,12 @@ namespace Tetris
             private const float kMinPositionX = -4.5f;
             // 右端の座標
             private const float kMaxPositionX = 4.5f;
+            // 左方向の移動
+            private readonly Vector3 kMoveLeftDirection = new Vector3(-1.0f, 0.0f, 0.0f);
+            // 右方向の移動
+            private readonly Vector3 kMoveRightDirection = new Vector3(1.0f, 0.0f, 0.0f);
+            // 下方向の移動
+            private readonly Vector3 kMoveDownDirection = new Vector3(0.0f, -1.0f, 0.0f);
 
             private const float _maxFlameRate = 60.0f;
 
@@ -146,14 +152,30 @@ namespace Tetris
                 _minoManager.GetComponent<MinoController>().HoldMino();
             }
 
+            // 移動先にミノがあるかチェックする。ある場合:true,移動できない。ない場合:false,移動できる。
+            // 引数は移動方向(x==1:右方向, x==-1:右方向, y==-1:下方向, y=1 or z!=0:無効な移動)
+            private bool CheckMovable(Vector3 direction)
+            {
+                // 無効な移動
+                if (direction.y == 1.0f || direction.z != 0.0f) return true;
+                bool retFlag = false;
+                // どこか一か所でもミノが存在(CheckMinoPlacementがtrue)の場合は移動できない
+                for (int i = 0; i < _componentBlock.Length; ++i)
+                {
+                    Vector3 checkPosition = _componentBlock[i].transform.position;
+                    checkPosition += direction;
+                    retFlag |= _minoManager.GetComponent<MinoController>().CheckMinoPlacement(checkPosition);
+                }
+                return retFlag;
+            }
+
             private void MoveLeft()
             {
                 // 移動ができるのはホールド状態でなく設置状態でもない時
                 if (_isHold || _isStable) return;
-                // 既に左端の場合は移動できない
-                if (_currentLeftPosition <= kMinPositionX) return;
-                Vector3 newMinoPosition = this.gameObject.transform.position;
-                newMinoPosition.x -= 1;
+                // 左に壁かミノがある場合移動できない
+                if (CheckMovable(kMoveLeftDirection)) return;
+                Vector3 newMinoPosition = this.gameObject.transform.position + kMoveLeftDirection;
                 this.gameObject.transform.position = newMinoPosition;
                 SetLeftRightPosition();
             }
@@ -162,10 +184,9 @@ namespace Tetris
             {
                 // 移動ができるのはホールド状態でなく設置状態でもない時
                 if (_isHold || _isStable) return;
-                // 既に右端の場合は移動できない
-                if (_currentRightPosition >= kMaxPositionX) return;
-                Vector3 newMinoPosition = this.gameObject.transform.position;
-                newMinoPosition.x += 1;
+                // 右に壁かミノがある場合移動できない
+                if (CheckMovable(kMoveRightDirection)) return;
+                Vector3 newMinoPosition = this.gameObject.transform.position + kMoveRightDirection;
                 this.gameObject.transform.position = newMinoPosition;
                 SetLeftRightPosition();
             }
@@ -176,11 +197,12 @@ namespace Tetris
                 CancelInvoke("MoveDownInvoke");
                 // 移動ができるのはホールド状態でなく設置状態でもない時
                 if (_isHold || _isStable) return;
-                // 下端に到達した
-
+                // これ以上下に移動できない場合、その位置にミノを固定する
+                if(CheckMovable(kMoveDownDirection)){
+                    return;
+                }
                 // ミノを1マス落とす
-                Vector3 newMinoPosition = this.gameObject.transform.position;
-                newMinoPosition.y -= 1;
+                Vector3 newMinoPosition = this.gameObject.transform.position + kMoveDownDirection;
                 // 自動落下を再開
                 this.gameObject.transform.position = newMinoPosition;
                 float repeatRate = _maxFlameRate / FixedLevel();
@@ -191,11 +213,12 @@ namespace Tetris
             // 時間経過でミノを落下させる
             private void MoveDownInvoke()
             {
-                // 下端に到達した
-
+                // これ以上下に移動できない場合、その位置にミノを固定する
+                if(CheckMovable(kMoveDownDirection)){
+                    return;
+                }
                 // ミノを1マス落とす
-                Vector3 newMinoPosition = this.gameObject.transform.position;
-                newMinoPosition.y -= 1;
+                Vector3 newMinoPosition = this.gameObject.transform.position + kMoveDownDirection;
                 // 自動落下させる
                 this.gameObject.transform.position = newMinoPosition;
                 float repeatRate = _maxFlameRate / FixedLevel();
@@ -215,12 +238,8 @@ namespace Tetris
                 // 回転中心オブジェクトをもとにz軸に90°回転
                 _rotationPivot.transform.Rotate(transform.forward, 90);
                 SetLeftRightPosition();
-                // もし回転で左右の壁を越えてしまった場合は回転をキャンセル
-                if (_currentLeftPosition < kMinPositionX || _currentRightPosition > kMaxPositionX)
-                {
-                    _rotationPivot.transform.Rotate(transform.forward, -90);
-                    SetLeftRightPosition();
-                }
+                // もし回転で左右の壁を越えてしまった場合はぶつからない位置まで横移動
+
             }
 
             // z軸に-90°
@@ -231,12 +250,8 @@ namespace Tetris
                 // 回転中心オブジェクトをもとにz軸に-90°回転
                 _rotationPivot.transform.Rotate(transform.forward, -90);
                 SetLeftRightPosition();
-                // もし回転で左右の壁を越えてしまった場合は回転をキャンセル
-                if (_currentLeftPosition < kMinPositionX || _currentRightPosition > kMaxPositionX)
-                {
-                    _rotationPivot.transform.Rotate(transform.forward, 90);
-                    SetLeftRightPosition();
-                }
+                // もし回転で左右の壁を越えてしまった場合はぶつからない位置まで横移動
+
             }
 
             public void SetMinoManager(GameObject minoManager)

--- a/Assets/Scripts/Mino/MinoController.cs
+++ b/Assets/Scripts/Mino/MinoController.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UnityEngine;
 using UniRx;
 using UniRx.Triggers;
+using Tetris.Mino;
 
 namespace Tetris
 {
@@ -22,111 +23,39 @@ namespace Tetris
 
         public class MinoController : MonoBehaviour
         {
+            // このスクリプトがアタッチされているゲームオブジェクト。MinoGeneraterもアタッチされている。
+            private GameObject MinoManager;
+
             // ミノの座標周りの定数
-            // ミノの生成位置。中心を中央から1マス左の位置になるように生成する。
-            private readonly Vector3 kStartingMinoPosition = new Vector3(-0.5f, 8.5f, 0f);
             // ホールドミノの座標。
             private readonly Vector3 kHoldMinoPosition = new Vector3(-7.5f, 7.0f, 0.0f);
-            // ネクストミノの座標。この値にOffsetY * 順番を引いた値が最終的な座標になる。
-            private readonly Vector3 kNextMinoPosition = new Vector3(7.5f, 7.5f, 0f);
-            // ネクストミノのy座標オフセット。
-            private const float kNextMinoOffsetY = 1.5f;
-
             // ミノの回転。ホールドに入れる際に使用
             private readonly Vector3 kHoldMinoRotation = new Vector3(0.0f, 0.0f, 0.0f);
-
-            // ミノのスケール。生成時は全て1、ホールド時は全て0.8、ネクストミノは全て0.5にする。
-            private readonly Vector3 kStartingMinoScale = new Vector3(1.0f, 1.0f, 1.0f);
+            // ホールド状態のミノのスケール。全て0.8。
             private readonly Vector3 kHoldMinoScale = new Vector3(0.8f, 0.8f, 0.8f);
-            private readonly Vector3 kNextMinoScale = new Vector3(0.5f, 0.5f, 0.5f);
 
             // ミノオブジェクト周りの変数
-            // ネクストミノの個数
-            private const int kMaxNextMinoSize = 6;
             // 現在フォーカスされているミノ
             private GameObject _currentMino;
             // ホールドされているミノ。最初にホールドされるまではnullオブジェクト。
             private GameObject _holdMino = null;
-            // ネクストミノオブジェクトを保持するキュー。常に6種類のミノを保持する。
-            private Queue<GameObject> _nextMinos;
-            // ネクストミノタイプを保持するキュー。ネクストミノは7種類のミノをランダムに並べたセットを繰り返す。
-            private Queue<Tetromino> _nextMinosType;
-            // テトリミノの種類一覧
-            private Tetromino[] _tetrominos = new Tetromino[] { Tetromino.IMino, Tetromino.JMino, Tetromino.LMino, Tetromino.OMino, Tetromino.SMino, Tetromino.TMino, Tetromino.ZMino };
-            // Resourcesフォルダにあるミノプレハブを所持するための配列
-            private GameObject[] _minoObjects;
 
             // ホールドをしていいかどうか
             private bool _canHold = true;
 
             private void Awake()
             {
-                _nextMinos = new Queue<GameObject>();
-                _nextMinosType = new Queue<Tetromino>();
+                MinoManager = this.gameObject;
+                this.enabled = false;
             }
 
             private void Start()
             {
-                _minoObjects = Resources.LoadAll<GameObject>("Tetromino");
-
-                SetNextMinosType();
-                for (int i = 0; i < kMaxNextMinoSize; ++i)
-                {
-                    GenerateNextMino();
-                }
-
                 // テトリミノを取得してゲーム開始
-                _currentMino = GetNextMino();
+                _currentMino = MinoManager.GetComponent<MinoGenerater>().GetNextMino();
                 _currentMino.GetComponent<MinoBehavior>().enabled = true;
                 _currentMino.GetComponent<MinoBehavior>().SetMinoManager(this.gameObject);
                 _currentMino.GetComponent<MinoBehavior>().StartMoveMino();
-            }
-
-            // 7種類のミノをシャッフルしてネクストミノの順番として保存。
-            private void SetNextMinosType()
-            {
-                Tetromino[] shuffledTetrominos = _tetrominos.OrderBy(i => System.Guid.NewGuid()).ToArray();
-                foreach (Tetromino item in shuffledTetrominos)
-                {
-                    _nextMinosType.Enqueue(item);
-                }
-            }
-
-            // _nextMinosTypeをもとにネクストミノオブジェクトを生成。
-            private void GenerateNextMino()
-            {
-                Tetromino nextMinoType = _nextMinosType.Dequeue();
-                GameObject generatedMino = Instantiate(_minoObjects[(int)nextMinoType]);
-                _nextMinos.Enqueue(generatedMino);
-                SetNextMinosPosition();
-            }
-
-            // ネクストミノの座標を調整
-            private void SetNextMinosPosition()
-            {
-                foreach (var (item, index) in _nextMinos.Select((item, index) => (item, index)))
-                {
-                    item.transform.position = kNextMinoPosition - new Vector3(0f, kNextMinoOffsetY * index, 0f);
-                    item.transform.localScale = kNextMinoScale;
-                }
-            }
-
-            // ネクストミノの先頭を取得し、次の操作ミノにする。
-            private GameObject GetNextMino()
-            {
-                // ネクストミノが6つ(次に呼び出すミノ+ネクストミノに残る5つ)まで減っていた場合は後ろに7つ追加する
-                if (_nextMinosType.Count <= kMaxNextMinoSize)
-                {
-                    SetNextMinosType();
-                }
-                // ネクストミノの先頭を取得し、末尾に一つ追加する。
-                GameObject nextMino = _nextMinos.Dequeue();
-                GenerateNextMino();
-
-                // 取得したミノを操作ミノの位置にセット
-                nextMino.transform.position = kStartingMinoPosition;
-                nextMino.transform.localScale = kStartingMinoScale;
-                return nextMino;
             }
 
             // 現在のミノが下まで到着した際に呼ばれる。
@@ -140,7 +69,7 @@ namespace Tetris
                 _canHold = true;
 
                 // テトリミノを取得して続ける。
-                _currentMino = GetNextMino();
+                _currentMino = MinoManager.GetComponent<MinoGenerater>().GetNextMino();
                 _currentMino.GetComponent<MinoBehavior>().enabled = true;
                 _currentMino.GetComponent<MinoBehavior>().SetMinoManager(this.gameObject);
                 _currentMino.GetComponent<MinoBehavior>().StartMoveMino();
@@ -150,7 +79,7 @@ namespace Tetris
             // 一度ホールドした場合、新しいミノを設置するまではホールド禁止。
             public bool canHoldMino()
             {
-                return _canHold || true;
+                return _canHold;
             }
 
             public void HoldMino()
@@ -169,7 +98,8 @@ namespace Tetris
                     _holdMino.transform.localScale = kHoldMinoScale;
 
                     // 次のミノを取得
-                    _currentMino = GetNextMino();
+                    _currentMino = MinoManager.GetComponent<MinoGenerater>().GetNextMino();
+                    _currentMino.GetComponent<MinoBehavior>().SetMinoManager(this.gameObject);
                 }
                 else
                 {
@@ -182,7 +112,6 @@ namespace Tetris
                     _holdMino.transform.localScale = kHoldMinoScale;
                     _currentMino = tmpMino;
                 }
-                Debug.Log("hold : " + _holdMino + " current : " + _currentMino);
                 // 次のミノのMinoBehaviorを有効にして開始。
                 _currentMino.GetComponent<MinoBehavior>().enabled = true;
                 _currentMino.GetComponent<MinoBehavior>().StartMoveMino();

--- a/Assets/Scripts/Mino/MinoGenerater.cs
+++ b/Assets/Scripts/Mino/MinoGenerater.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UniRx;
+using UniRx.Triggers;
+
+namespace Tetris
+{
+    namespace Mino
+    {
+        public class MinoGenerater : MonoBehaviour
+        {
+            // ミノの座標周りの定数
+            // ミノの生成位置。中心を中央から1マス左の位置になるように生成する。
+            private readonly Vector3 kStartingMinoPosition = new Vector3(-0.5f, 8.5f, 0f);
+            // ネクストミノの座標。この値にOffsetY * 順番を引いた値が最終的な座標になる。
+            private readonly Vector3 kNextMinoPosition = new Vector3(7.5f, 7.5f, 0f);
+            // ネクストミノのy座標オフセット。
+            private const float kNextMinoOffsetY = 1.5f;
+
+
+            // ミノのスケール。生成時は全て1、ネクストミノは全て0.5にする。
+            private readonly Vector3 kStartingMinoScale = new Vector3(1.0f, 1.0f, 1.0f);
+            private readonly Vector3 kNextMinoScale = new Vector3(0.5f, 0.5f, 0.5f);
+
+            // ミノオブジェクト周りの変数
+            // ネクストミノの個数
+            private const int kMaxNextMinoSize = 6;
+            // ネクストミノオブジェクトを保持するキュー。常に6種類のミノを保持する。
+            private Queue<GameObject> _nextMinos;
+            // ネクストミノタイプを保持するキュー。ネクストミノは7種類のミノをランダムに並べたセットを繰り返す。
+            private Queue<Tetromino> _nextMinosType;
+            // テトリミノの種類一覧
+            private Tetromino[] _tetrominos = new Tetromino[] { Tetromino.IMino, Tetromino.JMino, Tetromino.LMino, Tetromino.OMino, Tetromino.SMino, Tetromino.TMino, Tetromino.ZMino };
+            // Resourcesフォルダにあるミノプレハブを所持するための配列
+            private GameObject[] _minoObjects;
+
+            private void Awake()
+            {
+                _nextMinos = new Queue<GameObject>();
+                _nextMinosType = new Queue<Tetromino>();
+            }
+
+            private void Start()
+            {
+                _minoObjects = Resources.LoadAll<GameObject>("Tetromino");
+
+                SetNextMinosType();
+                for (int i = 0; i < kMaxNextMinoSize; ++i)
+                {
+                    GenerateNextMino();
+                }
+                this.gameObject.GetComponent<MinoController>().enabled = true;
+            }
+
+            // 7種類のミノをシャッフルしてネクストミノの順番として保存。
+            private void SetNextMinosType()
+            {
+                Tetromino[] shuffledTetrominos = _tetrominos.OrderBy(i => System.Guid.NewGuid()).ToArray();
+                foreach (Tetromino item in shuffledTetrominos)
+                {
+                    _nextMinosType.Enqueue(item);
+                }
+            }
+
+            // _nextMinosTypeをもとにネクストミノオブジェクトを生成。
+            private void GenerateNextMino()
+            {
+                Tetromino nextMinoType = _nextMinosType.Dequeue();
+                GameObject generatedMino = Instantiate(_minoObjects[(int)nextMinoType]);
+                _nextMinos.Enqueue(generatedMino);
+                SetNextMinosPosition();
+            }
+
+            // ネクストミノの座標を調整
+            private void SetNextMinosPosition()
+            {
+                foreach (var (item, index) in _nextMinos.Select((item, index) => (item, index)))
+                {
+                    item.transform.position = kNextMinoPosition - new Vector3(0f, kNextMinoOffsetY * index, 0f);
+                    item.transform.localScale = kNextMinoScale;
+                }
+            }
+
+            // ネクストミノの先頭を取得し、次の操作ミノにする。
+            public GameObject GetNextMino()
+            {
+                // ネクストミノが6つ(次に呼び出すミノ+ネクストミノに残る5つ)まで減っていた場合は後ろに7つ追加する
+                if (_nextMinosType.Count <= kMaxNextMinoSize)
+                {
+                    SetNextMinosType();
+                }
+                // ネクストミノの先頭を取得し、末尾に一つ追加する。
+                GameObject nextMino = _nextMinos.Dequeue();
+                GenerateNextMino();
+
+                // 取得したミノを操作ミノの位置にセット
+                nextMino.transform.position = kStartingMinoPosition;
+                nextMino.transform.localScale = kStartingMinoScale;
+                return nextMino;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Mino/MinoGenerater.cs.meta
+++ b/Assets/Scripts/Mino/MinoGenerater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00396e00ee0196a4ebd298998bc9738f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScoreManager.cs
+++ b/Assets/Scripts/ScoreManager.cs
@@ -1,0 +1,62 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Tetris
+{
+    public class ScoreManager : MonoBehaviour
+    {
+        // UIManagerオブジェクト
+        [SerializeField]
+        private GameObject _UIManagerObject;
+        // 現在のスコア
+        private int _currentScore = 0;
+        // ハイスコア
+        private int _highScore;
+        // ハイスコアを保存するためのキー
+        private const string kHighScoreKey = "HIGH SCORE";
+
+        // スコア周りの定数
+        // 列を削除した時の加算されるスコア=1000点
+        private const int kLineDeleteScore = 1000;
+        // ミノを↓キーで落とした時に加算されるスコア=10点
+        private const int kMinoDownScore = 10;
+
+        private void Awake()
+        {
+            _highScore = PlayerPrefs.GetInt(kHighScoreKey, 0);
+        }
+
+        private void Start()
+        {
+            _UIManagerObject.GetComponent<UI.ScoreDrawer>().ScoreDraw(_currentScore);
+            _UIManagerObject.GetComponent<UI.ScoreDrawer>().HiScoreDraw(_highScore);
+        }
+
+        // 実際にスコアを変更する関数
+        private void AddScore(int adderScore)
+        {
+            _currentScore += adderScore;
+            _UIManagerObject.GetComponent<UI.ScoreDrawer>().ScoreDraw(_currentScore);
+            if (_currentScore > _highScore)
+            {
+                _highScore = _currentScore;
+                PlayerPrefs.SetInt(kHighScoreKey, _highScore);
+                _UIManagerObject.GetComponent<UI.ScoreDrawer>().HiScoreDraw(_highScore);
+            }
+        }
+
+        // ライン削除時のスコア加算用
+        public void AddLineDeleteScore()
+        {
+            AddScore(kLineDeleteScore);
+        }
+
+        // ミノを1マス落とした時のスコア加算用
+        public void AddMinoDownScore()
+        {
+            AddScore(kMinoDownScore);
+        }
+    }
+}

--- a/Assets/Scripts/ScoreManager.cs.meta
+++ b/Assets/Scripts/ScoreManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 703326afbaa05644b95031e214fa49c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- ミノの生成・配置・取得関数類をMinoGenerater.csに移動、MinoControllerはゲーム進行の管理をメインにする
- ミノの設置状況をMinoController内の二次元配列で管理するように変更
- 座標ベースでしていた壁判定をミノの設置状況(true/false)で行う